### PR TITLE
Edited app.py so that the tables are created only once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__
 # SQLite database files
 *.db
 *.sqlite3
+
+.env

--- a/app.py
+++ b/app.py
@@ -40,9 +40,10 @@ app.register_blueprint(item_blueprint)
 app.register_blueprint(profile_blueprint)
 app.register_blueprint(auth_blueprint)
 
-# this should be removed for heroku deployment, but remove the comments  when you run the app locally
-# with app.app_context():
-#     db.create_all()
+# auto create tables in local dev only
+if uri.startswith("sqlite:///"):
+    with app.app_context():
+        db.create_all()
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Jinja2==3.1.3
 SQLAlchemy==2.0.44
 Werkzeug==3.1.3
 gunicorn==23.0.0
+psycopg2-binary


### PR DESCRIPTION
In the previous version, we would manually comment out the lines,

`with app.app_context():
        db.create_all()`
      

but it was not the best practice because then we would have to run these lines of code once on our terminal for heroku. this pr automates the process for us so that we do not have to deal with terminal commands ourselves.